### PR TITLE
RAG 기능을 채팅 완성 API에 통합

### DIFF
--- a/clovax/apis/v1/chat_completions/chat.py
+++ b/clovax/apis/v1/chat_completions/chat.py
@@ -3,6 +3,7 @@ from schemas.request.chat_completions_request import ChatRequest
 from schemas.response.chat_completions_response import ChatResponse
 from services.clova_chat_service import ClovaService
 from services.chat_memory_service import chat_memory_service
+from services.rag_retrieval_service import rag_retrieval_service, RetrievalConfig
 import uuid
 
 router = APIRouter()
@@ -32,7 +33,8 @@ clova_service = ClovaService()
                             "totalTokens": 25
                         }
                     },
-                    "sessionId": "550e8400-e29b-41d4-a716-446655440000"
+                    "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+                    "ragUsed": False
                 }
             }
         }
@@ -76,10 +78,17 @@ async def chat_completion(
     - sessionId와 함께 요청: 멀티턴 (이전 대화 기억)
     - 응답에 sessionId가 포함되어 다음 요청에서 사용 가능
     
+    **RAG (검색 증강 생성) 기능:**
+    - useRAG: true 설정 시 벡터 DB에서 관련 문서 검색
+    - ragTopK: 검색할 문서 개수 (기본값: 3, 범위: 1-10)
+    - ragThreshold: 유사도 임계값 (기본값: 0.1, 범위: 0.0-1.0)
+    - 검색된 문서를 바탕으로 정확한 답변 제공
+    
     **사용법:**
     1. 첫 번째 요청: sessionId 없이 전송
     2. 응답에서 sessionId 확인
     3. 이후 요청: sessionId 포함하여 전송
+    4. RAG 사용 시: useRAG=true로 설정
     """
     try:
         # 지원 모델 검증
@@ -156,6 +165,42 @@ async def chat_completion(
                     "content": content_array
                 })
 
+        # RAG 검색 수행 (useRAG가 True인 경우)
+        rag_context = ""
+        if chat_request.useRAG:
+            # 사용자 메시지에서 검색 쿼리 추출
+            user_messages = [msg for msg in current_messages if msg.get("role") == "user"]
+            if user_messages:
+                last_user_message = user_messages[-1].get("content", "")
+                if isinstance(last_user_message, list):
+                    # 배열 형태의 content에서 텍스트만 추출
+                    text_parts = [
+                        item.get("text", "") 
+                        for item in last_user_message 
+                        if isinstance(item, dict) and item.get("type") == "text"
+                    ]
+                    query = " ".join(text_parts)
+                else:
+                    query = last_user_message
+                
+                # RAG 검색 수행
+                if query.strip():
+                    retrieval_config = RetrievalConfig(
+                        top_k=chat_request.ragTopK or 3,
+                        similarity_threshold=chat_request.ragThreshold or 0.1
+                    )
+                    
+                    search_results = await rag_retrieval_service.search_documents_async(
+                        query=query,
+                        config=retrieval_config
+                    )
+                    
+                    # 검색 결과를 컨텍스트로 변환
+                    if search_results:
+                        rag_context = rag_retrieval_service._create_context_from_results(
+                            search_results, max_length=2000
+                        )
+
         # 멀티턴 지원: 이전 대화 내역과 현재 메시지 결합
         if chat_request.sessionId:
             messages = chat_memory_service.get_messages_for_clovax(
@@ -166,6 +211,39 @@ async def chat_completion(
         else:
             # 세션 ID가 없으면 현재 메시지만 사용 (기존 방식)
             messages = current_messages
+            
+        # RAG 컨텍스트가 있으면 기존 시스템 메시지에 통합
+        if rag_context:
+            rag_instruction = f"""
+
+[참고 문서]
+{rag_context}
+
+위 참고 문서를 바탕으로 사용자의 질문에 답변해주세요. 참고 문서의 내용을 바탕으로 정확한 정보를 제공하고, 참고 문서에 없는 내용은 추측하지 마세요. 답변 끝에 "※ 제공된 문서를 바탕으로 작성된 답변입니다."를 추가하세요."""
+            
+            # 기존 시스템 메시지를 찾아서 수정
+            system_message_found = False
+            for i, msg in enumerate(messages):
+                if msg.get("role") == "system":
+                    # 기존 시스템 메시지에 RAG 컨텍스트 추가
+                    if isinstance(msg["content"], str):
+                        messages[i]["content"] = msg["content"] + rag_instruction
+                    elif isinstance(msg["content"], list):
+                        # content가 배열인 경우 텍스트 부분에 추가
+                        for content_item in msg["content"]:
+                            if isinstance(content_item, dict) and content_item.get("type") == "text":
+                                content_item["text"] = content_item["text"] + rag_instruction
+                                break
+                    system_message_found = True
+                    break
+            
+            # 시스템 메시지가 없으면 새로 추가
+            if not system_message_found:
+                rag_system_message = {
+                    "role": "system",
+                    "content": f"친절하게 답변하는 AI 어시스턴트입니다.{rag_instruction}"
+                }
+                messages.insert(0, rag_system_message)
 
         # CLOVA Studio API 요청 데이터 준비 (JSON 직렬화 가능한 형태로 변환)
         clova_request = {
@@ -217,8 +295,9 @@ async def chat_completion(
                     memory_type=chat_request.memoryType or "buffer_window"
                 )
         
-        # 응답에 sessionId 추가
+        # 응답에 sessionId와 RAG 사용 여부 추가
         response["sessionId"] = session_id
+        response["ragUsed"] = bool(chat_request.useRAG and rag_context)
         
         return response
 

--- a/clovax/apis/v1/chat_completions/streaming.py
+++ b/clovax/apis/v1/chat_completions/streaming.py
@@ -170,7 +170,7 @@ async def streaming_chat_completion(
                     
                     # 검색 결과를 컨텍스트로 변환
                     if search_results:
-                        rag_context = rag_retrieval_service._create_context_from_results(
+                        rag_context = rag_retrieval_service.create_context_from_results(
                             search_results, max_length=2000
                         )
 

--- a/clovax/apis/v1/chat_completions/streaming.py
+++ b/clovax/apis/v1/chat_completions/streaming.py
@@ -4,6 +4,7 @@ from schemas.request.chat_completions_request import ChatRequest
 from schemas.response.chat_completions_response import ChatResponse
 from services.clova_chat_service import ClovaService
 from services.chat_memory_service import chat_memory_service
+from services.rag_retrieval_service import rag_retrieval_service, RetrievalConfig
 import uuid
 import json
 
@@ -50,6 +51,12 @@ async def streaming_chat_completion(
     - sessionId 없이 요청: 단일턴 (독립적인 대화)
     - sessionId와 함께 요청: 멀티턴 (이전 대화 기억)
     - 스트리밍 완료 시 sessionId가 포함되어 다음 요청에서 사용 가능
+    
+    **RAG (검색 증강 생성) 기능:**
+    - useRAG: true 설정 시 벡터 DB에서 관련 문서 검색
+    - ragTopK: 검색할 문서 개수 (기본값: 3, 범위: 1-10)
+    - ragThreshold: 유사도 임계값 (기본값: 0.1, 범위: 0.0-1.0)
+    - 검색된 문서를 바탕으로 정확한 답변을 스트리밍으로 제공
     
     **스트리밍 형식:**
     - Server-Sent Events (SSE) 형태로 응답
@@ -131,6 +138,42 @@ async def streaming_chat_completion(
                     "content": content_array
                 })
 
+        # RAG 검색 수행 (useRAG가 True인 경우)
+        rag_context = ""
+        if chat_request.useRAG:
+            # 사용자 메시지에서 검색 쿼리 추출
+            user_messages = [msg for msg in current_messages if msg.get("role") == "user"]
+            if user_messages:
+                last_user_message = user_messages[-1].get("content", "")
+                if isinstance(last_user_message, list):
+                    # 배열 형태의 content에서 텍스트만 추출
+                    text_parts = [
+                        item.get("text", "") 
+                        for item in last_user_message 
+                        if isinstance(item, dict) and item.get("type") == "text"
+                    ]
+                    query = " ".join(text_parts)
+                else:
+                    query = last_user_message
+                
+                # RAG 검색 수행
+                if query.strip():
+                    retrieval_config = RetrievalConfig(
+                        top_k=chat_request.ragTopK or 3,
+                        similarity_threshold=chat_request.ragThreshold or 0.1
+                    )
+                    
+                    search_results = await rag_retrieval_service.search_documents_async(
+                        query=query,
+                        config=retrieval_config
+                    )
+                    
+                    # 검색 결과를 컨텍스트로 변환
+                    if search_results:
+                        rag_context = rag_retrieval_service._create_context_from_results(
+                            search_results, max_length=2000
+                        )
+
         # 멀티턴 지원: 이전 대화 내역과 현재 메시지 결합
         if chat_request.sessionId:
             messages = chat_memory_service.get_messages_for_clovax(
@@ -141,6 +184,39 @@ async def streaming_chat_completion(
         else:
             # 세션 ID가 없으면 현재 메시지만 사용 (기존 방식)
             messages = current_messages
+            
+        # RAG 컨텍스트가 있으면 기존 시스템 메시지에 통합
+        if rag_context:
+            rag_instruction = f"""
+
+[참고 문서]
+{rag_context}
+
+위 참고 문서를 바탕으로 사용자의 질문에 답변해주세요. 참고 문서의 내용을 바탕으로 정확한 정보를 제공하고, 참고 문서에 없는 내용은 추측하지 마세요. 답변 끝에 "※ 제공된 문서를 바탕으로 작성된 답변입니다."를 추가하세요."""
+            
+            # 기존 시스템 메시지를 찾아서 수정
+            system_message_found = False
+            for i, msg in enumerate(messages):
+                if msg.get("role") == "system":
+                    # 기존 시스템 메시지에 RAG 컨텍스트 추가
+                    if isinstance(msg["content"], str):
+                        messages[i]["content"] = msg["content"] + rag_instruction
+                    elif isinstance(msg["content"], list):
+                        # content가 배열인 경우 텍스트 부분에 추가
+                        for content_item in msg["content"]:
+                            if isinstance(content_item, dict) and content_item.get("type") == "text":
+                                content_item["text"] = content_item["text"] + rag_instruction
+                                break
+                    system_message_found = True
+                    break
+            
+            # 시스템 메시지가 없으면 새로 추가
+            if not system_message_found:
+                rag_system_message = {
+                    "role": "system",
+                    "content": f"친절하게 답변하는 AI 어시스턴트입니다.{rag_instruction}"
+                }
+                messages.insert(0, rag_system_message)
 
         # CLOVA Studio API 요청 데이터 준비 (JSON 직렬화 가능한 형태로 변환)
         clova_request = {
@@ -213,11 +289,12 @@ async def streaming_chat_completion(
                             memory_type=chat_request.memoryType or "buffer_window"
                         )
                 
-                # 스트리밍 완료 신호 (sessionId 포함)
+                # 스트리밍 완료 신호 (sessionId와 RAG 사용 여부 포함)
                 completion_data = {
                     "status": "streaming_completed", 
                     "message": "스트리밍 완료",
-                    "sessionId": session_id
+                    "sessionId": session_id,
+                    "ragUsed": bool(chat_request.useRAG and rag_context)
                 }
                 yield f"data: {json.dumps(completion_data, ensure_ascii=False)}\n\n"
                 

--- a/clovax/apis/v1/chat_completions/streaming.py
+++ b/clovax/apis/v1/chat_completions/streaming.py
@@ -194,29 +194,8 @@ async def streaming_chat_completion(
 
 위 참고 문서를 바탕으로 사용자의 질문에 답변해주세요. 참고 문서의 내용을 바탕으로 정확한 정보를 제공하고, 참고 문서에 없는 내용은 추측하지 마세요. 답변 끝에 "※ 제공된 문서를 바탕으로 작성된 답변입니다."를 추가하세요."""
             
-            # 기존 시스템 메시지를 찾아서 수정
-            system_message_found = False
-            for i, msg in enumerate(messages):
-                if msg.get("role") == "system":
-                    # 기존 시스템 메시지에 RAG 컨텍스트 추가
-                    if isinstance(msg["content"], str):
-                        messages[i]["content"] = msg["content"] + rag_instruction
-                    elif isinstance(msg["content"], list):
-                        # content가 배열인 경우 텍스트 부분에 추가
-                        for content_item in msg["content"]:
-                            if isinstance(content_item, dict) and content_item.get("type") == "text":
-                                content_item["text"] = content_item["text"] + rag_instruction
-                                break
-                    system_message_found = True
-                    break
-            
-            # 시스템 메시지가 없으면 새로 추가
-            if not system_message_found:
-                rag_system_message = {
-                    "role": "system",
-                    "content": f"친절하게 답변하는 AI 어시스턴트입니다.{rag_instruction}"
-                }
-                messages.insert(0, rag_system_message)
+            # 시스템 메시지에 RAG 컨텍스트 추가 (공통 함수 사용)
+            add_rag_context_to_system_message(messages, rag_instruction)
 
         # CLOVA Studio API 요청 데이터 준비 (JSON 직렬화 가능한 형태로 변환)
         clova_request = {

--- a/clovax/schemas/request/chat_completions_request.py
+++ b/clovax/schemas/request/chat_completions_request.py
@@ -43,6 +43,9 @@ class ChatRequest(BaseModel):
     stop: Optional[List[str]] = Field([], description="중단 토큰 목록")
     seed: Optional[int] = Field(None, description="시드 값")
     includeAiFilters: Optional[bool] = Field(True, description="AI 필터 포함 여부")
+    useRAG: Optional[bool] = Field(False, description="RAG 검색 사용 여부")
+    ragTopK: Optional[int] = Field(3, description="RAG 검색 결과 개수", ge=1, le=10)
+    ragThreshold: Optional[float] = Field(0.1, description="RAG 유사도 임계값", ge=0.0, le=1.0)
 
     model_config = {
         "json_schema_extra": {
@@ -78,7 +81,10 @@ class ChatRequest(BaseModel):
                 "maxTokens": 100,
                 "temperature": 0.5,
                 "repetitionPenalty": 1.1,
-                "stop": []
+                "stop": [],
+                "useRAG": True,
+                "ragTopK": 3,
+                "ragThreshold": 0.1
                 
             }
         }

--- a/clovax/schemas/response/chat_completions_response.py
+++ b/clovax/schemas/response/chat_completions_response.py
@@ -39,6 +39,7 @@ class ChatResponse(BaseModel):
     status: Status = Field(..., description="응답 상태")
     result: Result = Field(..., description="응답 결과")
     sessionId: Optional[str] = Field(None, description="세션 ID (멀티턴 대화용)")
+    ragUsed: Optional[bool] = Field(False, description="RAG 검색 사용 여부")
     
     model_config = {
         "json_schema_extra": {
@@ -81,10 +82,11 @@ class ChatResponse(BaseModel):
                         }
                     ]
                 },
-                "sessionId": "550e8400-e29b-41d4-a716-446655440000"
+                "sessionId": "550e8400-e29b-41d4-a716-446655440000",
+                "ragUsed": False
             }
         },
-        "field_order": ["status", "result", "sessionId"],  # 필드 순서 명시
+        "field_order": ["status", "result", "sessionId", "ragUsed"],  # 필드 순서 명시
         "populate_by_name": True
     }
 


### PR DESCRIPTION
# RAG 기능을 채팅 완성 API에 통합

## 개요
CLOVAX의 채팅 완성 API에 RAG(Retrieval-Augmented Generation) 기능을 통합하여, 사용자 질문에 대해 벡터 데이터베이스의 관련 문서를 검색하고 이를 바탕으로 정확한 답변을 제공할 수 있도록 구현했습니다.

## 주요 기능

### RAG 통합
- **문서 검색**: 사용자 쿼리 기반으로 벡터 DB에서 관련 문서 검색
- **컨텍스트 생성**: 검색된 문서를 바탕으로 한 컨텍스트 생성
- **시스템 메시지 강화**: RAG 지시사항을 시스템 메시지에 통합
- **사용 추적**: 응답에 RAG 사용 여부를 포함하여 추적 가능

### 지원하는 API
- `POST /api/v1/chat-completions/{model_name}` - 일반 채팅 (RAG 지원)
- `POST /api/v1/chat-completions/{model_name}/stream` - 스트리밍 채팅 (RAG 지원)

### RAG 파라미터
- `useRAG`: RAG 검색 사용 여부 (기본값: false)
- `ragTopK`: 검색할 문서 개수 (기본값: 3, 범위: 1-10)
- `ragThreshold`: 유사도 임계값 (기본값: 0.1, 범위: 0.0-1.0)

## 기술적 구현

### 스키마 확장
```python
# ChatRequest에 추가된 필드
useRAG: Optional[bool] = Field(False, description="RAG 검색 사용 여부")
ragTopK: Optional[int] = Field(3, description="RAG 검색 결과 개수", ge=1, le=10)
ragThreshold: Optional[float] = Field(0.1, description="RAG 유사도 임계값", ge=0.0, le=1.0)

# ChatResponse에 추가된 필드
ragUsed: Optional[bool] = Field(False, description="RAG 검색 사용 여부")
```

### RAG 검색 로직
1. **쿼리 추출**: 사용자 메시지에서 검색 쿼리 추출
2. **문서 검색**: RAG 검색 서비스를 통한 벡터 검색
3. **컨텍스트 생성**: 검색 결과를 바탕으로 한 컨텍스트 생성
4. **시스템 메시지 통합**: RAG 지시사항을 시스템 메시지에 추가

### 시스템 메시지 예시
```
[참고 문서]
[문서 1] (유사도: 0.85, 출처: example.pdf)
참고 문서 내용...

위 참고 문서를 바탕으로 사용자의 질문에 답변해주세요. 
참고 문서의 내용을 바탕으로 정확한 정보를 제공하고, 
참고 문서에 없는 내용은 추측하지 마세요. 
답변 끝에 "※ 제공된 문서를 바탕으로 작성된 답변입니다."를 추가하세요.
```

## 사용 예시

### RAG를 사용한 채팅 요청
```json
{
  "messages": [
    {
      "role": "user",
      "content": "오픈소스 개발자 대회에 대해 알려줘"
    }
  ],
  "useRAG": true,
  "ragTopK": 5,
  "ragThreshold": 0.1
}
```

### 응답 예시
```json
{
  "status": {
    "code": "20000",
    "message": "OK"
  },
  "result": {
    "message": {
      "role": "assistant",
      "content": "오픈소스 개발자 대회는... ※ 제공된 문서를 바탕으로 작성된 답변입니다."
    }
  },
  "sessionId": "uuid-here",
  "ragUsed": true
}
```

## 변경사항 상세

### 새로 추가된 파일
- 없음 (기존 파일 수정)

### 수정된 파일
- `schemas/request/chat_completions_request.py` - RAG 필드 추가
- `schemas/response/chat_completions_response.py` - RAG 사용 여부 필드 추가
- `apis/v1/chat_completions/chat.py` - RAG 검색 로직 통합
- `apis/v1/chat_completions/streaming.py` - 스트리밍 채팅에 RAG 통합

## 테스트 방법

### 1. RAG 기능 테스트
```bash
# RAG를 사용한 채팅 요청
curl -X 'POST' 'http://localhost:8000/api/v1/chat-completions/HCX-005' \
  -H 'Content-Type: application/json' \
  -d '{
    "messages": [{"role": "user", "content": "테스트 질문"}],
    "useRAG": true,
    "ragTopK": 3,
    "ragThreshold": 0.1
  }'
```

### 2. 스트리밍 RAG 테스트
```bash
# RAG를 사용한 스트리밍 채팅 요청
curl -X 'POST' 'http://localhost:8000/api/v1/chat-completions/HCX-005/stream' \
  -H 'Content-Type: application/json' \
  -d '{
    "messages": [{"role": "user", "content": "테스트 질문"}],
    "useRAG": true
  }'
```

## 성능 및 제한사항

### 성능
- **검색 지연**: RAG 검색 시 추가 지연 발생 (벡터 검색 + 컨텍스트 생성)
- **토큰 사용량**: RAG 컨텍스트로 인한 토큰 사용량 증가

### 제한사항
- RAG 사용 시 `useRAG: true` 설정 필요
- 벡터 DB에 색인된 문서가 있어야 함
- 검색 결과가 없으면 일반 채팅으로 동작

## 체크리스트

- [x] RAG 필드를 채팅 요청 스키마에 추가
- [x] RAG 사용 여부를 채팅 응답에 포함
- [x] 일반 채팅 API에 RAG 검색 로직 통합
- [x] 스트리밍 채팅 API에 RAG 검색 로직 통합
- [x] 시스템 메시지에 RAG 지시사항 통합
- [x] RAG 파라미터 검증 및 기본값 설정
- [x] 에러 처리 및 예외 상황 대응
- [x] API 문서화 업데이트

## 주의사항

1. **RAG 사용 시**: `useRAG: true`로 설정해야 RAG 검색이 활성화됩니다
2. **문서 색인**: RAG를 사용하기 전에 벡터 DB에 문서를 색인해야 합니다
3. **성능 고려**: RAG 검색으로 인한 응답 지연이 발생할 수 있습니다
4. **토큰 제한**: RAG 컨텍스트가 토큰 제한에 포함되므로 주의가 필요합니다

## 향후 개선 계획

- [ ] RAG 검색 결과 캐싱 구현
- [ ] RAG 컨텍스트 길이 자동 조정
- [ ] RAG 검색 실패 시 대체 처리 로직
- [ ] RAG 사용 통계 및 모니터링
