### PR TITLE
feat: rag_csv_loader 추가

### DIFF
--- a/clovax/services/rag_document_csv_loader.py
+++ b/clovax/services/rag_document_csv_loader.py
@@ -1,0 +1,174 @@
+from langchain_community.document_loaders import CSVLoader
+from langchain.schema import Document
+from typing import List, Optional, Dict, Any
+import logging
+import os
+import pandas as pd
+import tempfile
+
+logger = logging.getLogger(__name__)
+
+class CSVDocumentLoaderService:
+    """CSV 문서 로더 서비스"""
+
+    def __init__(self):
+        self.supported_extensions = ['.csv']
+
+    def load_csv(self, file_path: str, encoding: str = 'utf-8') -> List[Document]:
+        """
+        CSV 파일을 로드하여 Document 리스트로 반환합니다.
+
+        Args:
+            file_path: CSV 파일 경로
+            encoding: 파일 인코딩 (기본값: utf-8)
+
+        Returns:
+            List[Document]: 로드된 Document 리스트
+        """
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"파일을 찾을 수 없습니다: {file_path}")
+
+        if not file_path.lower().endswith('.csv'):
+            raise ValueError("지원하지 않는 파일 형식입니다. CSV 파일만 허용됩니다.")
+
+        try:
+            # pandas로 CSV 파일 읽기
+            df = pd.read_csv(file_path, encoding=encoding)
+            
+            if df.empty:
+                logger.warning("CSV 파일이 비어 있습니다.")
+                return []
+
+            documents = []
+            
+            # 각 행을 Document로 변환
+            for idx, row in df.iterrows():
+                # 한 행의 텍스트 변환
+                row_text = self._row_to_text(row, df.columns.tolist())
+                
+                # 메타데이터 생성
+                metadata = {
+                    'source_file': os.path.basename(file_path),
+                    'file_type': 'csv',
+                    'loader_type': 'CSVLoader',
+                    'row_index': int(idx),
+                    'total_rows': len(df)
+                }
+                
+                # 각 컬럼별 메타데이터 추가
+                for col in df.columns:
+                    metadata[f'col_{col}'] = str(row[col]) if pd.notna(row[col]) else ""
+                
+                doc = Document(
+                    page_content=row_text,
+                    metadata=metadata
+                )
+                documents.append(doc)
+
+            logger.info(f"CSV 문서 로드 완료: {len(documents)}개 문서")
+            return documents
+
+        except UnicodeDecodeError:
+            # UTF-8로 읽기 실패 시 cp949, latin-1 순서로 재시도
+            try:
+                return self.load_csv(file_path, encoding='cp949')
+            except:
+                try:
+                    return self.load_csv(file_path, encoding='euc-kr')
+                except:
+                    try:
+                        return self.load_csv(file_path, encoding='latin-1')
+                    except Exception as e:
+                        logger.error(f"CSV 파일 인코딩 오류: {str(e)}")
+                        raise Exception(f"CSV 파일 인코딩을 확인할 수 없습니다: {str(e)}")
+        except Exception as e:
+            logger.error(f"CSV 파일 로드 오류: {str(e)}")
+            raise Exception(f"CSV 파일 로드 중 오류 발생: {str(e)}")
+
+    def _row_to_text(self, row: pd.Series, columns: List[str]) -> str:
+        """
+        pandas Series(한 행)를 텍스트로 변환합니다.
+
+        Args:
+            row: pandas Series (한 행)
+            columns: 컬럼명 리스트
+
+        Returns:
+            str: 한 행의 텍스트
+        """
+        text_parts = []
+        
+        for col in columns:
+            value = row[col]
+            if pd.notna(value) and str(value).strip():
+                text_parts.append(f"{col}: {str(value).strip()}")
+        
+        return " | ".join(text_parts)
+
+    def preprocess_text(self, text: str) -> str:
+        """
+        텍스트 전처리
+
+        Args:
+            text: 원본 텍스트
+
+        Returns:
+            str: 전처리된 텍스트
+        """
+        if not text:
+            return ""
+
+        # 공백 문자 정규화
+        import re
+        text = re.sub(r'\s+', ' ', text)
+        
+        # 양쪽 공백 제거
+        text = text.strip()
+
+        return text
+
+    def load_and_preprocess(self, file_path: str, encoding: str = 'utf-8') -> List[Document]:
+        """
+        CSV 파일을 로드하고 전처리하여 반환합니다.
+
+        Args:
+            file_path: CSV 파일 경로
+            encoding: 파일 인코딩
+
+        Returns:
+            List[Document]: 전처리된 Document 리스트 (빈 텍스트 제외)
+        """
+        # 1. CSV 로드 (각 행을 Document로)
+        documents = self.load_csv(file_path, encoding)
+
+        # 2. 각 Document의 텍스트 전처리
+        processed_documents = []
+        for doc in documents:
+            processed_text = self.preprocess_text(doc.page_content)
+            if processed_text.strip():  # 빈 텍스트는 제외
+                processed_doc = Document(
+                    page_content=processed_text,
+                    metadata=doc.metadata
+                )
+                processed_documents.append(processed_doc)
+
+        logger.info(f"전처리된 CSV 문서 개수: {len(processed_documents)}개")
+        return processed_documents
+
+    def save_temp_csv_file(self, file_content: bytes, filename: str) -> str:
+        """
+        업로드된 CSV 파일을 임시 파일로 저장합니다.
+
+        Args:
+            file_content: CSV 파일 바이너리 데이터
+            filename: 원본 파일명
+
+        Returns:
+            str: 임시 파일 경로
+        """
+        with tempfile.NamedTemporaryFile(delete=False, suffix='.csv', prefix=f"{filename}_") as tmp_file:
+            tmp_file.write(file_content)
+            return tmp_file.name
+
+# 싱글턴 인스턴스
+csv_document_loader_service = CSVDocumentLoaderService()

--- a/clovax/services/rag_document_pdf_loader_service.py
+++ b/clovax/services/rag_document_pdf_loader_service.py
@@ -1,0 +1,129 @@
+from langchain_community.document_loaders import PyMuPDFLoader
+from langchain.schema import Document
+from typing import List, Optional
+import logging
+import os
+import re
+
+logger = logging.getLogger(__name__)
+
+class DocumentLoaderService:
+    """PDF 문서 로더 서비스"""
+
+    def __init__(self):
+        self.supported_extensions = ['.pdf']
+
+    def load_pdf(self, file_path: str) -> List[Document]:
+        """
+        PDF 파일을 로드하여 Document 리스트로 반환합니다.
+
+        Args:
+            file_path: PDF 파일 경로
+
+        Returns:
+            List[Document]: 로드된 Document 리스트
+        """
+        if not os.path.exists(file_path):
+            raise FileNotFoundError(f"파일을 찾을 수 없습니다: {file_path}")
+
+        if not file_path.lower().endswith('.pdf'):
+            raise ValueError("지원하지 않는 파일 형식입니다. PDF 파일만 허용됩니다.")
+
+        try:
+            loader = PyMuPDFLoader(file_path)
+            documents = loader.load()
+
+            # 메타데이터 추가
+            for doc in documents:
+                doc.metadata['source_file'] = os.path.basename(file_path)
+                doc.metadata['file_type'] = 'pdf'
+                doc.metadata['loader_type'] = 'PyMuPDFLoader'
+
+            logger.info(f"PDF 문서 로드 완료: {len(documents)}개 문서")
+            return documents
+
+        except Exception as e:
+            logger.error(f"PDF 로드 오류: {str(e)}")
+            raise Exception(f"PDF 로드 중 오류 발생: {str(e)}")
+
+    def preprocess_text(self, text: str) -> str:
+        """
+        텍스트 전처리
+
+        Args:
+            text: 원본 텍스트
+
+        Returns:
+            str: 전처리된 텍스트
+        """
+        if not text:
+            return ""
+
+        # 1. 연속된 공백을 하나로 치환
+        text = re.sub(r'\s+', ' ', text)
+
+        # 2. 허용된 문자(한글, 영문, 숫자, 일부 특수문자)만 남김
+        text = re.sub(r'[^\w\s가-힣.,!?;:()\-\'"]+', '', text)
+
+        # 3. 연속된 개행을 하나로 치환
+        text = re.sub(r'\n+', '\n', text)
+
+        # 4. 양쪽 공백 제거
+        text = text.strip()
+
+        return text
+
+    def merge_documents_by_page(self, documents: List[Document]) -> List[Document]:
+        """
+        여러 페이지의 Document를 하나로 합칩니다.
+
+        Args:
+            documents: 원본 Document 리스트
+
+        Returns:
+            List[Document]: 병합된 Document 리스트
+        """
+        if not documents:
+            return []
+
+        merged_docs = []
+        current_content = ""
+        current_metadata = documents[0].metadata.copy()
+
+        for doc in documents:
+            # 텍스트 전처리
+            processed_text = self.preprocess_text(doc.page_content)
+
+            if processed_text.strip():
+                current_content += processed_text + "\n\n"
+
+        if current_content.strip():
+            merged_doc = Document(
+                page_content=current_content.strip(),
+                metadata=current_metadata
+            )
+            merged_docs.append(merged_doc)
+
+        return merged_docs
+
+    def load_and_preprocess(self, file_path: str) -> List[Document]:
+        """
+        PDF 파일을 로드하고 전처리하여 반환합니다.
+
+        Args:
+            file_path: PDF 파일 경로
+
+        Returns:
+            List[Document]: 전처리된 Document 리스트
+        """
+        # 1. PDF 로드
+        documents = self.load_pdf(file_path)
+
+        # 2. 페이지 병합 및 전처리
+        processed_documents = self.merge_documents_by_page(documents)
+
+        logger.info(f"전처리된 문서 개수: {len(processed_documents)}개")
+        return processed_documents
+
+# 싱글톤 인스턴스 생성
+document_loader_service = DocumentLoaderService()


### PR DESCRIPTION
## 개요

* CSV 형식의 문서를 업로드하고 RAG 파이프라인에 색인할 수 있는 **CSV 로더 API**를 추가했습니다.
* 기존 PDF 로더와 동일한 워크플로우(추출 → 전처리 → 청킹 → 임베딩 → 색인)를 CSV에도 적용할 수 있도록 개선했습니다.

---

##  주요 변경 사항

* `@router.post("/documents/upload_csv")` 엔드포인트 추가

  * 지원 파일: CSV
  * CSV 데이터 로드 및 전처리 로직 추가
  * `clova_text_splitter_service`를 활용한 CSV 내용 청킹 처리
  * `clova_embedding_service` 및 `chroma_indexing_service` 연동
* 요청/응답 모델은 PDF 업로드 API와 동일한 `DocumentIndexRequest`, `DocumentIndexResponse`를 사용
* 파일 크기 제한(50MB) 및 확장자 검증 로직 포함
* 에러 처리 및 로깅 추가

---

## 📊 영향 범위

* 신규 CSV 업로드 기능 추가
* 기존 PDF 업로드 및 검색 기능은 영향 없음
* `services/rag_document_csv_loader_service.py` 신규 추가

---

## 🔍 체크리스트

* [x] CSV 문서 업로드 API 정상 동작 확인
* [x] CSV → 청킹 → 임베딩 → 색인 흐름 테스트 완료
* [x] 50MB 이상 파일 업로드 시 예외 처리 동작 확인
* [ ] 대규모 CSV(행 10만 개 이상) 처리 성능 검증 (추후 필요)

